### PR TITLE
feat(api): Use the [data-mstr-id] attribute for event handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a list of all properties of the `HtmlUiElementRegisteredEvent` see the Confi
 You can also opt to use custom prebuilt elements by using the `"data-mstr-standard"` attribute with the desired element name as the value. This will **replace** the element on which the attribute is set with the prebuilt element.
 
 ```HTML
-<div id="custom-element-1" data-mstr-events="mouseover" class="custom-wrapper-class">
+<div data-mstr-id="custom-element-1" data-mstr-events="mouseover" class="custom-wrapper-class">
     <div class="seekbar-container">
         <span data-mstr-standard="seekbar"></span>
     </div>
@@ -97,7 +97,7 @@ Options are required unless marked as [optional].
     - **events** :: *String[]*  
         List of eventnames that were registered on the element.
     - **id** :: *String*  
-        The id of the element, should it have one.
+        The `data-mstr-id` of the element, should it have one.
     - **meister**  :: *Meister*  
         The meister instance this element registered the events on.
 * [optional] **standard** :: *Object*  
@@ -111,13 +111,13 @@ Options are required unless marked as [optional].
 
 Optionally you can use the eventbus of Meisterplayer to register and handle UI-events from the HtmlUi. An advantage of using Meister's eventbus is the reference to the meister-instance which triggered the UI-event, you would have to maintain a registry of instances and some way to determine the instance that fired an UI-event if you'd chosen to implement your own event-handling.
 
-You can register events to your elements by setting the `data-mstr-events` attribute on the element, with a comma seperated list of eventnames as the value. Should one of the specified events trigger on the DOM node this will be emitted through the Meister instance's event bus with the following format: `"ui:[<element-id>]:<eventtype>"`.
+You can register events to your elements by setting the `data-mstr-events` attribute on the element, with a comma seperated list of eventnames as the value. Should one of the specified events trigger on the DOM node this will be emitted through the Meister instance's event bus with the following format: `"ui:[<element[data-mstr-id]>]:<eventtype>"`.
 
 For example, take the template below:
 
 ```HTML
-<div id="custom-element-1" data-mstr-events="mouseover" class="custom-wrapper-class">
-    <div id="custom-element-2" data-mstr-events="mousedown, mousemove, mouseup" class="custom-inner-class">
+<div data-mstr-id="custom-element-1" data-mstr-events="mouseover" class="custom-wrapper-class">
+    <div data-mstr-id="custom-element-2" data-mstr-events="mousedown, mousemove, mouseup" class="custom-inner-class">
         <div data-mstr-events="click" class="custom-button-class">
 
         </div>
@@ -131,7 +131,7 @@ As you can see it contains three elements, and all three elements have the `data
 - "ui:custom-element-2:mousedown"
 - "ui:custom-element-2:mousemove"
 - "ui:custom-element-2:mouseup"
-- "ui:click" (Since the innermost `div` does not have an id the event is not namespaced)
+- "ui:click" (Since the innermost `div` does not have an data-mstr-id the event is not namespaced)
 
 You can register callbacks for these handles on the Meister instance: 
 
@@ -147,7 +147,7 @@ All custom ui events callbacks are called with a `HtmlUiEvent` as the single arg
 - **event** :: *Event*  
     The original DOM event.
 - **eventName** :: *String*  
-    The complete event string the callback was registered under. Follows the following format `"ui:[<element-id>]:<eventtype>"`.
+    The complete event string the callback was registered under. Follows the following format `"ui:[<element[data-mstr-id]>]:<eventtype>"`.
 - **eventType** :: *String*  
     The type of event, that was emitted from the DOM. Examples include `"mouseover"` or `"click"`. This is always the same as the `<eventtype>` part of the eventName.
 - **meister** :: *Meister*  

--- a/src/js/lib/constants.js
+++ b/src/js/lib/constants.js
@@ -12,6 +12,14 @@ export const CUSTOM_UI_EVENT_PREFIX = 'ui';
  * @type {String}
  * @default
  */
+export const MEISTER_DATA_ID_ATTR = 'data-mstr-id';
+
+/**
+ * @constant
+ * @memberof module:CustomUi
+ * @type {String}
+ * @default
+ */
 export const MEISTER_DATA_EVENTS_ATTR = 'data-mstr-events';
 
 /**

--- a/src/js/lib/event-classes.js
+++ b/src/js/lib/event-classes.js
@@ -1,3 +1,4 @@
+import { MEISTER_DATA_ID_ATTR } from './constants';
 /**
  * An event used as a callback arguments in custom ui events proxying DOM events.
  * @typedef {Object} module:CustomUi~CustomUiEvent
@@ -46,6 +47,6 @@ export class CustomUiElementRegisteredEvent {
         this.meister = meister;
         this.element = domNode;
         this.events = events;
-        this.id = domNode.id;
+        this.id = domNode.getAttribute(MEISTER_DATA_ID_ATTR);
     }
 }

--- a/src/js/lib/event-node-functions.js
+++ b/src/js/lib/event-node-functions.js
@@ -1,4 +1,4 @@
-import { CUSTOM_UI_EVENT_PREFIX, MEISTER_DATA_EVENTS_ATTR } from './constants';
+import { CUSTOM_UI_EVENT_PREFIX, MEISTER_DATA_EVENTS_ATTR, MEISTER_DATA_ID_ATTR } from './constants';
 import { extractNodesWithSelector } from './utilities';
 import { CustomUiEvent, CustomUiElementRegisteredEvent } from './event-classes';
 
@@ -60,7 +60,8 @@ export function createRegisterDataEvents(meister, onElementRegistered = () => {}
         const eventsArray = extractEvents(rawAttributes);
         if (eventsArray.length < 1) { return; }
 
-        const domNodeId = domNode.id ? `${domNode.id}:` : '';
+        const rawDomNodeId = domNode.getAttribute(MEISTER_DATA_ID_ATTR);
+        const domNodeId = rawDomNodeId ? `${rawDomNodeId}:` : '';
         const handleName = `${CUSTOM_UI_EVENT_PREFIX}:${domNodeId}`;
 
         eventsArray.forEach((eventName) => {


### PR DESCRIPTION
Previously the id of the element was used to create the event handle,
but this can lead to situations where multiple elements use the same id
when displaying multiple players.

Closes #8, meisterplayer/meisterplayer#66